### PR TITLE
Fix Hero component gradient width to use 100% instead of 100vw

### DIFF
--- a/src/components/overrides/Hero.astro
+++ b/src/components/overrides/Hero.astro
@@ -64,7 +64,7 @@ if (image) {
 		z-index: -1;
 		top: calc(var(--sl-nav-height) + var(--sl-mobile-toc-height));
 		left: 0;
-		width: 100vw;
+		width: 100%;
 		height: calc(20rem + clamp(2.5rem, calc(1rem + 10vmin), 10rem));
 		
 		/* Dark gradient */


### PR DESCRIPTION
This pull request includes a small change to the `src/components/overrides/Hero.astro` file. The change modifies the width property of the background gradient from 100vw to 100% - as it's causing horizontal overflow issues.

Before and after comparison:
![image](https://github.com/user-attachments/assets/2d3b5695-7e22-472d-8e9a-f3487ee07f40)
![image](https://github.com/user-attachments/assets/2ae2a585-ff3f-4163-949e-78a85790bc97)




Tested using Chrome 132, Firefox 136 on Windows 11, as well as Safari 18.3.